### PR TITLE
Fix minor bug with staff feed source

### DIFF
--- a/django-verdant/rca/models.py
+++ b/django-verdant/rca/models.py
@@ -2256,11 +2256,10 @@ class StandardIndex(Page, SocialFields, OptionalBlockFields):
         if self.staff_feed_source:
             feed_source = StaffPage.objects.filter(school=self.staff_feed_source)
             for staffpage in feed_source:
-
-            try:
-                staffpage.staff_role = staffpage.roles.filter(school=self.staff_feed_source)[0].title
-            except IndexError:
-                pass
+                try:
+                    staffpage.staff_role = staffpage.roles.filter(school=self.staff_feed_source)[0].title
+                except IndexError:
+                    pass
 
         # Chain manual_feed + feed_source (any or both may be empty)
         feed = chain(manual_feed, feed_source)


### PR DESCRIPTION
If for some reason a staff does _not_ have roles for the school he belongs to then an exception will be thrown when rendering the staff_feed_source. This shouln't happen under normal circumstances since a Staff member of a school should have a role for that school.

In any case, the behavior has been changed to just output an empty role instead of throwing the exception.
