### PR TITLE
Add common RelatedLinksFields allowing empty text

### DIFF
--- a/django-verdant/rca/models.py
+++ b/django-verdant/rca/models.py
@@ -446,6 +446,30 @@ class CarouselItemFields(models.Model):
     class Meta:
         abstract = True
 
+# Related link item abstract class - all related links basically require the same fields
+class RelatedLinkItemFields(models.Model):
+    # I don't know why the link field is optional -- however I'll leave it that way
+    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
+    link_text = models.CharField(max_length=255, help_text="Link title (or leave blank to use page title)", null=True, blank=True)
+
+    panels = [
+        PageChooserPanel('link'),
+        FieldPanel('link_text'),
+    ]
+
+    @property
+    def get_link_text(self):
+        if self.link_text:
+            return self.link_text
+        else:
+            try:
+                return self.link.title
+            except:
+                return None
+
+    class Meta:
+        abstract = True
+
 
 # == Snippet: Advert ==
 
@@ -624,15 +648,8 @@ class SchoolPageContactEmail(Orderable):
         FieldPanel('email_address')
     ]
 
-class SchoolPageRelatedLink(Orderable):
+class SchoolPageRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.SchoolPage', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class SchoolPageAd(Orderable):
     page = ParentalKey('rca.SchoolPage', related_name='manual_adverts')
@@ -750,15 +767,8 @@ class ProgrammePageManualStaffFeed(Orderable):
         FieldPanel('staff_role'),
     ]
 
-class ProgrammePageRelatedLink(Orderable):
+class ProgrammePageRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.ProgrammePage', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class ProgrammePageContactPhone(Orderable):
     page = ParentalKey('rca.ProgrammePage', related_name='contact_phone')
@@ -1614,15 +1624,8 @@ EventItem.promote_panels = [
 
 # == Event index ==
 
-class EventIndexRelatedLink(Orderable):
+class EventIndexRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.EventIndex', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class EventIndexAd(Orderable):
     page = ParentalKey('rca.EventIndex', related_name='manual_adverts')
@@ -1891,15 +1894,8 @@ ReviewsIndex.promote_panels = [
 class ReviewPageCarouselItem(Orderable, CarouselItemFields):
     page = ParentalKey('rca.ReviewPage', related_name='carousel_items')
 
-class ReviewPageRelatedLink(Orderable):
+class ReviewPageRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.ReviewPage', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class ReviewPageQuotation(Orderable):
     page = ParentalKey('rca.ReviewPage', related_name='quotations')
@@ -1994,15 +1990,8 @@ ReviewPage.promote_panels = [
 class StandardPageCarouselItem(Orderable, CarouselItemFields):
     page = ParentalKey('rca.StandardPage', related_name='carousel_items')
 
-class StandardPageRelatedLink(Orderable):
+class StandardPageRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.StandardPage', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class StandardPageQuotation(Orderable):
     page = ParentalKey('rca.StandardPage', related_name='quotations')
@@ -2143,15 +2132,8 @@ class StandardIndexStaffFeed(Orderable):
         FieldPanel('staff_role'),
     ]
 
-class StandardIndexRelatedLink(Orderable):
+class StandardIndexRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.StandardIndex', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class StandardIndexContactPhone(Orderable):
     page = ParentalKey('rca.StandardIndex', related_name='contact_phone')
@@ -2357,15 +2339,8 @@ class HomePageAd(Orderable):
         SnippetChooserPanel('ad', Advert),
     ]
 
-class HomePageRelatedLink(Orderable):
+class HomePageRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.HomePage', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class HomePage(Page, SocialFields):
     background_image = models.ForeignKey('rca.RcaImage', null=True, blank=True, on_delete=models.SET_NULL, related_name='+', help_text="The full bleed image in the background")
@@ -2593,15 +2568,8 @@ JobPage.promote_panels = [
 
 # == Jobs index page ==
 
-class JobsIndexRelatedLink(Orderable):
+class JobsIndexRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.JobsIndex', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class JobsIndexAd(Orderable):
     page = ParentalKey('rca.JobsIndex', related_name='manual_adverts')
@@ -2652,15 +2620,8 @@ JobsIndex.promote_panels = [
 
 # == Alumni index page ==
 
-class AlumniIndexRelatedLink(Orderable):
+class AlumniIndexRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.AlumniIndex', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class AlumniIndexAd(Orderable):
     page = ParentalKey('rca.AlumniIndex', related_name='manual_adverts')
@@ -3796,6 +3757,7 @@ class ResearchItemLink(Orderable):
         FieldPanel('link'),
         FieldPanel('link_text')
     ]
+    
 class ResearchItem(Page, SocialFields):
     subtitle = models.CharField(max_length=255, blank=True)
     research_type = models.CharField(max_length=255, choices=RESEARCH_TYPES_CHOICES)
@@ -3916,15 +3878,8 @@ class ResearchInnovationPageTeaser(Orderable):
         FieldPanel('text'),
     ]
 
-class ResearchInnovationPageRelatedLink(Orderable):
+class ResearchInnovationPageRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.ResearchInnovationPage', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
 
 class ResearchInnovationPageContactPhone(Orderable):
     page = ParentalKey('rca.ResearchInnovationPage', related_name='contact_phone')
@@ -4113,16 +4068,8 @@ CurrentResearchPage.promote_panels = [
 
 # == Gallery Page ==
 
-class GalleryPageRelatedLink(Orderable):
+class GalleryPageRelatedLink(Orderable, RelatedLinkItemFields):
     page = ParentalKey('rca.GalleryPage', related_name='related_links')
-    link = models.ForeignKey(Page, null=True, blank=True, related_name='+')
-    link_text = models.CharField(max_length=255, help_text="Link title")
-
-    panels = [
-        PageChooserPanel('link'),
-        FieldPanel('link_text'),
-    ]
-
 
 class GalleryPage(Page, SocialFields):
     intro = RichTextField(blank=True)

--- a/django-verdant/rca/templates/rca/tags/sidebar_links.html
+++ b/django-verdant/rca/templates/rca/tags/sidebar_links.html
@@ -20,8 +20,8 @@
                     <h3>See also</h3>
                     <ul class="extra-links">
                     {% for link in related_links %}
-                        {% if link.link and link.link_text %}
-                            <li><a href="{% pageurl link.link %}">{{ link.link_text }}</a></li>
+                        {% if link.link and link.get_link_text %}
+                            <li><a href="{% pageurl link.link %}">{{ link.get_link_text }}</a></li>
                         {% endif %}
                     {% endfor %}
                     </ul>


### PR DESCRIPTION
This adds a RelatedLinkItemFields Abstract class defining common fields for Relate Links. These common RelatedLink fields existed in the following:

SchoolPageRelatedLink, ProgrammePageRelatedLink, EventIndexRelatedLink,
ReviewPageRelatedLink, StandardPageRelatedLink, StandardIndexRelatedLink,
HomePageRelatedLink, JobsIndexRelatedLink, AlumniIndexRelatedLink,
ResearchInnovationPageRelatedLink, GalleryPageRelatedLink

so all were refactored to inherit from RelatedLinkItemFields.

One thing here is that the link field in the previous was optional - I left it also optional in the base class but can somebody explain why it had to be optional ? I think that it should've been required.

The link_text field in RelatedLinkItemFields is optional. To get the title for the link the get_link_text property has to be used. This will check to see if the link_text field has a value - if not then the title of the
related page will be used.

The sidebar_link.html template has been modified to use the get_link_text.
