### PR TITLE
[Sentry #2034] Fixed crash when looking up manual adverts for sidebar

### DIFF
--- a/django-verdant/rca/templatetags/rca_tags.py
+++ b/django-verdant/rca/templatetags/rca_tags.py
@@ -263,13 +263,16 @@ def homepage_packery(context, calling_page=None, news_count=5, staff_count=5, st
 
 @register.inclusion_tag('rca/tags/sidebar_adverts.html', takes_context=True)
 def sidebar_adverts(context, show_open_days=False):
+    self = context.get('self')
+    manual_adverts = getattr(self, 'manual_adverts', None)
+
     return {
         'promoted_global_adverts': Advert.objects.filter(show_globally=True, promoted=True),
-        'promoted_manual_adverts': context.get('self').manual_adverts.filter(ad__promoted=True),
+        'promoted_manual_adverts': manual_adverts.filter(ad__promoted=True) if manual_adverts else [],
         'global_adverts': Advert.objects.filter(show_globally=True, promoted=False),
-        'manual_adverts': context.get('self').manual_adverts.filter(ad__promoted=False),
+        'manual_adverts': manual_adverts.filter(ad__promoted=False) if manual_adverts else [],
         'show_open_days': show_open_days,
-        'self': context.get('self'),
+        'self': self,
         'global_events_index_url': context['global_events_index_url'],
         'request': context['request'],
     }


### PR DESCRIPTION
https://sentry.torchbox.com/torchbox/rca-main-site/issues/2034/

The code assumed that every single content type had manual adverts