### PR TITLE
Run tests on Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,19 @@ build:
     # Check for missing migrations
     - bash -c "! python manage.py makemigrations -e --dry-run --noinput"
 
+    # Run tests
+    - python manage.py test
+
+  environment:
+    - PGHOST=127.0.0.1
+    - PGUSER=postgres
+
 cache:
   mount:
     - /drone/pip-cache
+
+compose:
+  db:
+    image: postgres:9.4
+  cache:
+    image: redis:2.8


### PR DESCRIPTION
Requires Django 1.9 because ruuning the migrations on Django 1.8 maxes out Drone's memory