### PR TITLE
[#830] Added hide_animation_videos flag to ShowIndexPage

### DIFF
--- a/django-verdant/rca/templatetags/rca_tags.py
+++ b/django-verdant/rca/templatetags/rca_tags.py
@@ -604,14 +604,14 @@ def get_debug():
 
 
 @register.assignment_tag
-def get_student_carousel_items(student, degree=None, show_animation_videos=False):
+def get_student_carousel_items(student, degree=None, hide_animation_videos=True):
     profile = student.get_profile(degree)
     if not profile['carousel_items']:
         return []
     carousel_items = profile['carousel_items'].all()
 
     # If this is an animation student, remove the first two carousel items if they are vimeo videos
-    if show_animation_videos == False and profile['programme'].slug in ['animation', 'visualcommunication']:
+    if hide_animation_videos and profile['programme'].slug in ['animation', 'visualcommunication']:
         for i in range(2):
             try:
                 first_carousel_item = carousel_items[0]

--- a/django-verdant/rca_show/migrations/0008_showindexpage_hide_animation_videos.py
+++ b/django-verdant/rca_show/migrations/0008_showindexpage_hide_animation_videos.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rca_show', '0007_auto_20160628_1605'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='showindexpage',
+            name='hide_animation_videos',
+            field=models.BooleanField(default=True, help_text=b'If this box is checked, videos embedded in the carousel will not be displayed on Animation and Visual Communication student profiles'),
+        ),
+    ]

--- a/django-verdant/rca_show/models.py
+++ b/django-verdant/rca_show/models.py
@@ -309,6 +309,7 @@ class ShowIndexPage(SuperPage, SocialFields):
     exhibition_date = models.TextField(max_length=255, blank=True)
     parent_show_index = models.ForeignKey('rca_show.ShowIndexPage', null=True, blank=True, on_delete=models.SET_NULL)
     password_prompt = models.CharField(max_length=255, blank=True, help_text="A custom message asking the user to log in, on protected pages")
+    hide_animation_videos = models.BooleanField(default=True, help_text="If this box is checked, videos embedded in the carousel will not be displayed on Animation and Visual Communication student profiles")
 
     password_required_template = "rca_show/login.html"
 
@@ -584,6 +585,7 @@ class ShowIndexPage(SuperPage, SocialFields):
         InlinePanel('programmes', label="Programmes"),
         PageChooserPanel('parent_show_index'),
         FieldPanel('password_prompt'),
+        FieldPanel('hide_animation_videos'),
     ]
 
     promote_panels = [

--- a/django-verdant/rca_show/templates/rca_show/student.html
+++ b/django-verdant/rca_show/templates/rca_show/student.html
@@ -13,11 +13,7 @@
 
     {% tabdeck %}
         {% tab "Show RCA work" %}
-            {% if "animation" in self.get_programmes or "visualcommunication" in self.get_programmes %}
-                {% get_student_carousel_items student show_animation_videos=True as carousel_items %}
-            {% else %}
-                {% get_student_carousel_items student as carousel_items %}
-            {% endif %}
+            {% get_student_carousel_items student hide_animation_videos=self.hide_animation_videos as carousel_items %}
             {% include "rca_show/includes/modules/carousel.html" %}
 
             <section class="row">
@@ -32,13 +28,13 @@
                                     {% elif student.mphil_in_show and student.mphil_graduation_year == self.year %}
                                         {{ student.get_mphil_programme_display }}
                                     {% elif student.phd_in_show and student.phd_graduation_year == self.year %}
-                                        {{ student.get_phd_programme_display }}    
+                                        {{ student.get_phd_programme_display }}
                                     {% endif %}
                                 </dd>
-                                
+
                                 {% if student.phones %}
                                     <dt>Phone</dt>
-                                    <dd class="ellipsis">            
+                                    <dd class="ellipsis">
                                         {% for phone in student.phones.all %}
                                             <div>{{ phone.phone }}</div>
                                         {% endfor %}
@@ -82,11 +78,11 @@
                                     <span>{{ student.get_show_work_type_display }}:</span>
                                 {% endif %}
                             {% else %}
-                                Dissertation: 
+                                Dissertation:
                             {% endif %}
                         </h2>
 
-                    
+
                         <h3>
                         {% if student.ma_in_show and student.ma_graduation_year == self.year %}
                             {{ student.show_work_title }}
@@ -94,7 +90,7 @@
                             {{ student.mphil_dissertation_title }}
                         {% elif student.phd_in_show and student.phd_graduation_year == self.year %}
                             {{ student.phd_dissertation_title }}
-                        {% endif %}                         
+                        {% endif %}
                         </h3>
 
                         {% if student.ma_in_show and student.ma_graduation_year == self.year %}
@@ -103,7 +99,7 @@
                             {{ student.mphil_statement|richtext }}
                         {% elif student.phd_in_show and student.phd_graduation_year == self.year %}
                             {{ student.phd_statement|richtext }}
-                        {% endif %}                            
+                        {% endif %}
                     </div>
                 </div>
             </section>
@@ -141,7 +137,7 @@
                                 PhD {{ student.get_phd_programme_display }}
                             {% endif %}
                         </p>
-        
+
 
                         {% if student.ma_specialism %}
                             <h3 class="a2 space">Specialism</h3>
@@ -352,12 +348,12 @@
                                 </li>
                             </ul>
                     {% endif %}
-                {% endwith %}      
+                {% endwith %}
 
             </div>
-        {% endtab %}        
-    {% endtabdeck %}    
-   
+        {% endtab %}
+    {% endtabdeck %}
+
 {% endblock %}
 
 {% block sidebar %}

--- a/django-verdant/rca_show/templates/rca_show/student_2016.html
+++ b/django-verdant/rca_show/templates/rca_show/student_2016.html
@@ -13,11 +13,7 @@
 
     {% tabdeck %}
         {% tab "Show RCA work" %}
-            {% if "animation" in self.get_programmes or "visualcommunication" in self.get_programmes %}
-                {% get_student_carousel_items student show_animation_videos=True as carousel_items %}
-            {% else %}
-                {% get_student_carousel_items student as carousel_items %}
-            {% endif %}
+            {% get_student_carousel_items student hide_animation_videos=self.hide_animation_videos as carousel_items %}
             {% include "rca_show/includes/modules/carousel.html" %}
 
             <section class="row">


### PR DESCRIPTION
https://projects.torchbox.com/projects/rca-django-cms-project/tickets/830

We need to hide animation videos in every carousel except on the private animation show pages.

We previously relied on a bit of template logic to control this, but that logic broke recently. This commit replaces this logic with a "hide_animation_videos" checkbox (default to checked) that an administrator can uncheck on pages where animation videos should be allowed.