### PR TITLE
Fix offline compression

### DIFF
--- a/django-verdant/rcasite/settings/base.py
+++ b/django-verdant/rcasite/settings/base.py
@@ -214,6 +214,7 @@ COMPRESS_PRECOMPILERS = (
     ('text/less', 'lessc {infile} {outfile}'),
 )
 COMPRESS_OFFLINE = True
+COMPRESS_OFFLINE_CONTEXT = 'rcasite.utils.offline_context'
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/django-verdant/rcasite/utils.py
+++ b/django-verdant/rcasite/utils.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+
+from rca_show.models import ShowIndexPage
+from rca_show.utils import get_base_show_template
+
+
+def offline_context():
+    """
+    We use dynamic base template for some RCA Show templates,
+    so we need to pass correct base_template into context
+    during offline compression.
+    """
+
+    years = ShowIndexPage.objects.order_by().values_list('year', flat=True).distinct()
+
+    for year in years:
+        yield {
+            'STATIC_URL': settings.STATIC_URL,
+            'base_template': get_base_show_template(year),
+        }


### PR DESCRIPTION
Some RCA Show templates use dynamic base template, so we need to pass it into context during offline compression.

Related #108