### PR TITLE
[884] Ensure that the field_type is always set

### DIFF
--- a/django-verdant/rca_ee/wtforms.py
+++ b/django-verdant/rca_ee/wtforms.py
@@ -24,9 +24,10 @@ class ExtendedAbstractFormField(AbstractFormField):
     # yes, that is wasted space but not much anyway
     new_field_type = models.CharField(verbose_name=_('Field type'), max_length=16, choices=FORM_FIELD_CHOICES)
 
-    def save(self, *args, **kwargs):
-        self.field_type = self.new_field_type
-        return super(AbstractFormField, self).save(*args, **kwargs)
+    def __setattr__(self, name, value):
+        if name == 'new_field_type':
+            self.field_type = value
+        return super(ExtendedAbstractFormField, self).__setattr__(name, value)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Field type was only being set during save, this meant that during preview stages where no save takes place the page would error when it attempted to render the form as `field_type=''`. This change ensures that `field_type` is kept in sync with any change to `new_field_type`.
