### PR TITLE
Wagtail does not pin point the upper version of REST framework

### DIFF
--- a/django-verdant/requirements.txt
+++ b/django-verdant/requirements.txt
@@ -19,6 +19,7 @@ raven==5.26.0
 dj-database-url==0.4.2
 ConcurrentLogHandler==0.9.1
 django-cors-headers==1.2.1
+djangorestframework>=3.1.3,<3.7
 
 # Developer requirements
 django-debug-toolbar==0.11.0


### PR DESCRIPTION
Fix for requirements following local copy build errors.