### PR TITLE
Add option for full width pages with no sidebar

### DIFF
--- a/django-verdant/rca/templates/rca/base.html
+++ b/django-verdant/rca/templates/rca/base.html
@@ -163,14 +163,18 @@
 
             <div class="page-wrapper">
                 <div class="page-content">
-                    <div class="inner" id="maincontent">
-                        {% block top %}{% endblock %}
-                        {% block content %}{% endblock %}
-                    </div>
+                    {% block layout %}
+                        <div class="inner" id="maincontent">
+                            {% block top %}{% endblock %}
+                            {% block content %}{% endblock %}
+                        </div>
+                    {% endblock %}
                 </div>
-                <aside>
-                    {% block sidebar %}{% endblock %}
-                </aside>
+                {% block aside %}
+                    <aside>
+                        {% block sidebar %}{% endblock %}
+                    </aside>
+                {% endblock %}
             </div>
 
             {% block extra_footer %}{% endblock %}

--- a/django-verdant/rca/templates/rca/full_width.html
+++ b/django-verdant/rca/templates/rca/full_width.html
@@ -1,0 +1,12 @@
+{% extends "rca/base.html" %}
+
+
+{# Full width layout #}
+{% block layout %}
+    {% block top %}{% endblock %}
+    {% block content %}{% endblock %}
+{% endblock %}
+
+{# No aside #}
+{% block aside %}
+{% endblock %}

--- a/django-verdant/rca/templates/rca/home_page_2018.html
+++ b/django-verdant/rca/templates/rca/home_page_2018.html
@@ -1,3 +1,7 @@
-<h1>2018 Homepage</h1>
+{% extends "rca/full_width.html" %}
 
-{{ use_2018_redesign_template }}
+
+{% block content %}
+    {{ use_2018_redesign_template }}
+    content for homepage goes here
+{% endblock %}


### PR DESCRIPTION
- Add extra blocks to base.html to allow overrides to aside and inner div
- Create a full_width.html template which will add the full width overrides
- Make the new home page template extend full_width.html