### PR TITLE
953 showcase mobile amends

### DIFF
--- a/django-verdant/rca/static/rca/css/components/slider.less
+++ b/django-verdant/rca/static/rca/css/components/slider.less
@@ -17,21 +17,15 @@
         position: absolute;
         background-image: none;
         z-index: 1;
-        width: 24px;
-        height: 42px;
-
-        @media @media-desktop-small {
-            width: 32px;
-            height: 64px;
-        }
+        width: 32px;
+        height: 64px;
 
         &--next {
-            right: 16px;
+            right: 4px;
             top: calc(~"50% - 31px");
 
             @media @media-desktop-regular {
                 top: 30%;
-                right: 4px;
             }
 
             @media @media-desktop-large {
@@ -65,6 +59,10 @@
         &--prev {
             left: 4px;
             top: calc(~"50% - 31px");
+
+            @media @media-desktop-regular {
+                top: 30%;
+            }
 
             @media @media-desktop-large {
                 top: 35%;

--- a/django-verdant/rca/static/rca/css/components/slider.less
+++ b/django-verdant/rca/static/rca/css/components/slider.less
@@ -52,7 +52,7 @@
                 top: 30%;
 
                 @media @media-desktop-regular {
-                    right: 22px;
+                    right: 9px;
                     top: 20%;
                 }
 
@@ -84,7 +84,7 @@
                 top: 30%;
 
                 @media @media-desktop-regular {
-                    left: 22px;
+                    left: 9px;
                     top: 20%;
                 }
 

--- a/django-verdant/rca/static/rca/css/streamfield-blocks/events.less
+++ b/django-verdant/rca/static/rca/css/streamfield-blocks/events.less
@@ -56,7 +56,7 @@
                 height: 100%;
                 position: absolute;
                 top: 0;
-                background-color: @color-black;
+                background-color: @color-charcoal;
 
                 @media @media-desktop-regular {
                     .opacity(60);

--- a/django-verdant/rca/static/rca/css/streamfield-blocks/showcase.less
+++ b/django-verdant/rca/static/rca/css/streamfield-blocks/showcase.less
@@ -13,6 +13,7 @@
 
     &__slide {
         float: left; // stops so much jumping before the carousel loads
+        padding: 0 3px;
 
         @media @media-desktop-regular {
             padding-left: @spacing-half;
@@ -109,6 +110,22 @@
             @media @media-desktop-regular {
                 padding-right: @imagePadding;
                 transform: translate(@imagePadding, 0);
+            }
+        }
+
+        .showcase__image-wrapper {
+
+            //solid overlay at mobile for the 2 partially hidden slides
+            &:after {
+                .opacity(100);
+                background-color: @color-charcoal;
+            }
+
+            @media @media-desktop-regular {
+                &:after {
+                    .opacity(20);
+                    background-color: @color-black;
+                }
             }
         }
 

--- a/django-verdant/rca/static/rca/js/events-block.js
+++ b/django-verdant/rca/static/rca/js/events-block.js
@@ -10,7 +10,7 @@ $(function(){
         nextArrow: nextButton,
         infinte: true,
         centerMode: true,
-        centerPadding: '5vw',
+        centerPadding: 'calc(5vw - 8px)',
         slidesToShow: 3,
         responsive: [
             {
@@ -18,7 +18,7 @@ $(function(){
                 breakpoint: 1024,
                 settings: {
                     slidesToShow: 1,
-                    centerPadding: '17px',
+                    centerPadding: '13px',
                 }
             }
         ]

--- a/django-verdant/rca/static/rca/js/events-block.js
+++ b/django-verdant/rca/static/rca/js/events-block.js
@@ -10,15 +10,22 @@ $(function(){
         nextArrow: nextButton,
         infinte: true,
         centerMode: true,
-        centerPadding: 'calc(5vw - 8px)',
+        centerPadding: 'calc(5vw - 8px)',  // offset minus padding between items
         slidesToShow: 3,
         responsive: [
-            {
-                // mobile
+             {
+                // small desktop
                 breakpoint: 1024,
                 settings: {
-                    slidesToShow: 1,
-                    centerPadding: '13px',
+                    centerPadding: '5vw', // offset
+                    slidesToShow: 1
+                }
+            },
+            {
+                breakpoint: 768,
+                settings: {
+                    centerPadding: '13px', // just works
+                    slidesToShow: 1
                 }
             }
         ]

--- a/django-verdant/rca/static/rca/js/showcase-block.js
+++ b/django-verdant/rca/static/rca/js/showcase-block.js
@@ -9,15 +9,22 @@ $(function(){
         prevArrow: prevButton,
         nextArrow: nextButton,
         centerMode: true,
-        infinte:true,
+        infinte: true,
         slidesToShow: 3,
+        centerPadding: 'calc(5vw - 8px)', // offset minus padding between items
         responsive: [
             {
-                // small desktop / mobile
+                // small desktop
                 breakpoint: 1024,
                 settings: {
-                    centerMode: true,
-                    centerPadding: '40px',
+                    centerPadding: '5vw', // offset
+                    slidesToShow: 1
+                }
+            },
+            {
+                breakpoint: 768,
+                settings: {
+                    centerPadding: '13px', // just works
                     slidesToShow: 1
                 }
             }

--- a/django-verdant/rca/templates/rca/home_page_2018.html
+++ b/django-verdant/rca/templates/rca/home_page_2018.html
@@ -59,7 +59,7 @@
 
 {% block extra_js %}
 
-    {# showcase carousel using slick #}
+    {# carousels are using slick #}
     <script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
 
     <script src="{% static "rca/js/showcase-block.js" %}"></script>


### PR DESCRIPTION
Not just showcase despite the branch name. This ensures that for both the events carousel and the showcase carousel, the sliver of image showing aligns with the title above. Arrow positioning adjusted as best as possible - would need some js to position perfectly.

Beth, please could you check this doesn't impact on the testimonial block at all?