### PR TITLE
Remove push state across the site

### DIFF
--- a/django-verdant/rca/templates/rca/base.html
+++ b/django-verdant/rca/templates/rca/base.html
@@ -220,7 +220,6 @@
                 <script src="{% static "rca/js/tweets.js" %}"></script>
                 <script src="{% static "rca/js/site.js" %}"></script>
                 <script src="{% static "rca/js/nav.js" %}"></script>
-                <script src="{% static "rca/js/pushstate.js" %}"></script>
 
 
                 {# ADROLL https://projects.torchbox.com/projects/rca-django-cms-project/tickets/846 #}


### PR DESCRIPTION
- For now, simply remove the call to pushstate.js in base.html
- At a later date, requires a proper tidy up to remove all associated code and styling.