### PR TITLE
Remove priority menu from menu.html - not needed until new header goe…

### DIFF
--- a/django-verdant/rca/templates/rca/menu.html
+++ b/django-verdant/rca/templates/rca/menu.html
@@ -1,4 +1,2 @@
 {% load rca_tags %}
 {% menu %}
-
-{% priority_menu %}


### PR DESCRIPTION
…s live, and it was duplicating the breadcrumb.