### PR TITLE
Update api to allow querying by programme type

### DIFF
--- a/django-verdant/rca/api/endpoints.py
+++ b/django-verdant/rca/api/endpoints.py
@@ -4,6 +4,7 @@ from wagtail.api.v2.endpoints import PagesAPIEndpoint
 from wagtail.wagtailimages.api.v2.endpoints import ImagesAPIEndpoint
 
 from .serializers import RCAPageSerializer, RCAImageSerializer
+from .filters import RelatedProgrammesFilter, NextEventOrder
 
 
 class RCAPagesAPIEndpoint(PagesAPIEndpoint):
@@ -22,6 +23,15 @@ class RCAPagesAPIEndpoint(PagesAPIEndpoint):
 
     # Allow the parent field to appear on listings
     detail_only_fields = []
+
+    filter_backends = [
+        RelatedProgrammesFilter,
+        NextEventOrder,
+    ] + PagesAPIEndpoint.filter_backends
+    known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
+        'rp',
+        'event_date_from',
+    ])
 
 
 class RCAImagesAPIEndpoint(ImagesAPIEndpoint):

--- a/django-verdant/rca/api/filters.py
+++ b/django-verdant/rca/api/filters.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from rest_framework import filters
+
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models.fields.related import ForeignObjectRel, OneToOneRel
+from rca.models import EventItemDatesTimes, EventItem
+
+class RelatedProgrammesFilter(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        if hasattr(queryset.model, 'related_programmes'):
+            rp = request.GET.getlist('rp', [])
+            if rp:
+                queryset = queryset.filter(related_programmes__programme__slug__in=rp)
+
+        if hasattr(queryset.model, 'related_programme'):
+            rp = request.GET.getlist('rp', [])
+            if rp:
+                queryset = queryset.filter(related_programme__slug__in=rp)
+
+        if hasattr(queryset.model, 'roles'):
+            rp = request.GET.getlist('rp', [])
+            if rp:
+                queryset = queryset.filter(roles__programme__slug__in=rp)
+
+        return queryset
+
+
+class NextEventOrder(filters.OrderingFilter):
+    def filter_queryset(self, request, queryset, view):
+        if hasattr(queryset.model, 'dates_times'):
+            date_from = request.query_params.get('event_date_from', None)
+            if date_from:
+                now = datetime.utcnow().date()
+                queryset = queryset.filter(dates_times__date_from__gte=now)
+                queryset = queryset.order_by('dates_times__date_from')
+
+        return queryset
+
+

--- a/django-verdant/rcasite/settings/dev.py
+++ b/django-verdant/rcasite/settings/dev.py
@@ -20,3 +20,5 @@ try:
     from .local import *
 except ImportError:
     pass
+
+ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
Updates the current API to allow filtering content by programme type. 
We plan to make this request in the new live site for related content areas. Also added a filter to bring back EventItems ordered by date closest to `now`