### PR TITLE
Fixes a double domain bug in the image path, thumnail.url now include…

### DIFF
--- a/django-verdant/rca/api/serializers.py
+++ b/django-verdant/rca/api/serializers.py
@@ -11,12 +11,6 @@ from wagtail.wagtailimages.models import SourceImageIOError
 from wagtail.wagtailimages.api.v2.serializers import ImageSerializer
 
 
-def get_main_site_root_url():
-    for site_id, root_path, root_url in Site.get_site_root_paths():
-        if root_path == '/home/':
-            return root_url
-
-
 def get_model_listing_url(context, model):
     url_path = context['router'].get_model_listing_urlpath(model)
 
@@ -138,10 +132,9 @@ class ImageRenditionField(Field):
     def to_representation(self, image):
         try:
             thumbnail = image.get_rendition(self.filter_spec)
-            root_url = get_main_site_root_url()
 
             return OrderedDict([
-                ('url', root_url + thumbnail.url),
+                ('url', thumbnail.url),
                 ('width', thumbnail.width),
                 ('height', thumbnail.height),
             ])

--- a/django-verdant/rca/templates/rca/base.html
+++ b/django-verdant/rca/templates/rca/base.html
@@ -49,14 +49,14 @@
         <meta name="twitter:title" content="{{ self.title }}">
         <meta name="twitter:description" content="{% if self.social_text %}{{ self.social_text }}{% else %}Royal College of Art{% endif %}">
         {% image self.social_image width-320 as social_img %}
-        <meta name="twitter:image:src" content="http://{% if self.social_image %}{{ request.site.hostname }}{{ social_img.url }}{% else %}{{ request.site.hostname }}/static/rca/images/social.png{% endif %}">
+        <meta name="twitter:image:src" content="http://{% if self.social_image %}{{ social_img.url }}{% else %}{{ request.site.hostname }}/static/rca/images/social.png{% endif %}">
 
         <!--facebook opengraph-->
         <meta property="fb:app_id" content="775982992428351" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="{{ self.url }}" />
         <meta property="og:title" content="{{ self.title }}" />
-        <meta property="og:image" content="http://{% if self.social_image %}{{ request.site.hostname }}{{ social_img.url }}{% else %}{{ request.site.hostname }}/static/rca/images/social.png{% endif %}" />
+        <meta property="og:image" content="http://{% if self.social_image %}{{ social_img.url }}{% else %}{{ request.site.hostname }}/static/rca/images/social.png{% endif %}" />
         <meta property="og:description" content="{% if self.social_text %}{{ self.social_text }}{% else %}Royal College of Art{% endif %}" />
         <meta property="og:site_name" content="Royal College of Art" />
 


### PR DESCRIPTION
…s the site root as we switched to django-storages and s3

Test on https://rca-verdant-staging.herokuapp.com/api/v2/images/1/
Image url paths should now be good.