### PR TITLE
Add wagtail sitemap

### DIFF
--- a/django-verdant/rcasite/settings/base.py
+++ b/django-verdant/rcasite/settings/base.py
@@ -170,7 +170,8 @@ INSTALLED_APPS = [
     'wagtail.contrib.settings',
     'wagtail.wagtailforms',
     'wagtail.contrib.modeladmin',
-    'wagtail.contrib.wagtailsitemaps',
+    'django.contrib.sitemaps',
+    'rcasitemaps',
 
     'wagtailcaptcha',
     'captcha',

--- a/django-verdant/rcasite/settings/base.py
+++ b/django-verdant/rcasite/settings/base.py
@@ -170,6 +170,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.settings',
     'wagtail.wagtailforms',
     'wagtail.contrib.modeladmin',
+    'wagtail.contrib.wagtailsitemaps',
 
     'wagtailcaptcha',
     'captcha',

--- a/django-verdant/rcasite/urls.py
+++ b/django-verdant/rcasite/urls.py
@@ -12,6 +12,7 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtaildocs.api.v2.endpoints import DocumentsAPIEndpoint
 from wagtail.wagtailimages import urls as wagtailimages_urls
 from wagtail.utils.urlpatterns import decorate_urlpatterns
+from wagtail.contrib.wagtailsitemaps.views import sitemap
 
 from wagtail.api.v2.router import WagtailAPIRouter
 from rca.api.endpoints import RCAPagesAPIEndpoint, RCAImagesAPIEndpoint
@@ -75,6 +76,7 @@ urlpatterns = patterns('',
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism
     url(r'', include(wagtail_urls)),
+    url('^sitemap\.xml$', sitemap),
 )
 
 

--- a/django-verdant/rcasite/urls.py
+++ b/django-verdant/rcasite/urls.py
@@ -12,7 +12,7 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtaildocs.api.v2.endpoints import DocumentsAPIEndpoint
 from wagtail.wagtailimages import urls as wagtailimages_urls
 from wagtail.utils.urlpatterns import decorate_urlpatterns
-from wagtail.contrib.wagtailsitemaps.views import sitemap
+from rcasitemaps.views import index, sitemap
 
 from wagtail.api.v2.router import WagtailAPIRouter
 from rca.api.endpoints import RCAPagesAPIEndpoint, RCAImagesAPIEndpoint
@@ -22,12 +22,14 @@ from rca import admin_urls as rca_admin_urls
 from twitter import urls as twitter_urls
 import student_profiles.urls, student_profiles.now_urls
 from taxonomy import views as taxonomy_views
+from rcasitemaps.sitemap_generator import Sitemap
 from . import admin_views
 
 from rcasite.cache import get_default_cache_control_decorator
 
 admin.autodiscover()
 
+sitemaps = {'wagtail': Sitemap}
 
 # Signal handlers
 from wagtail.wagtailsearch.signal_handlers import register_signal_handlers as wagtailsearch_register_signal_handlers
@@ -76,7 +78,10 @@ urlpatterns = patterns('',
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism
     url(r'', include(wagtail_urls)),
-    url('^sitemap\.xml$', sitemap),
+
+    url(r'^sitemap\.xml$', index, {'sitemaps': sitemaps}),
+    url(r'^sitemap-(?P<section>.+)\.xml$', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
+
 )
 
 

--- a/django-verdant/rcasitemaps/sitemap_generator.py
+++ b/django-verdant/rcasitemaps/sitemap_generator.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.contrib.sitemaps import Sitemap as DjangoSitemap
+
+
+class Sitemap(DjangoSitemap):
+
+    limit = 500
+
+    def __init__(self, site=None):
+        self.site = site
+
+    def location(self, obj):
+        return obj.specific.url
+
+    def lastmod(self, obj):
+        obj = obj.specific
+
+        # fall back on latest_revision_created_at if last_published_at is null
+        # (for backwards compatibility from before last_published_at was added)
+        return (obj.last_published_at or obj.latest_revision_created_at)
+
+    def items(self):
+        return (
+            self.site
+            .root_page
+            .get_descendants(inclusive=True)
+            .live()
+            .public()
+            .order_by('path'))
+
+    def _urls(self, page, protocol, domain):
+        urls = []
+        last_mods = set()
+
+        for item in self.paginator.page(page).object_list:
+            for url_info in item.specific.get_sitemap_urls():
+                urls.append(url_info)
+                last_mods.add(url_info.get('lastmod'))
+
+        if None not in last_mods:
+            self.latest_lastmod = max(last_mods)
+        return urls
+

--- a/django-verdant/rcasitemaps/sitemap_generator.py
+++ b/django-verdant/rcasitemaps/sitemap_generator.py
@@ -11,7 +11,7 @@ class Sitemap(DjangoSitemap):
         self.site = site
 
     def location(self, obj):
-        return obj.specific.url
+        return obj.url
 
     def lastmod(self, obj):
         obj = obj.specific

--- a/django-verdant/rcasitemaps/views.py
+++ b/django-verdant/rcasitemaps/views.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.contrib.sitemaps import views as sitemap_views
+
+from .sitemap_generator import Sitemap
+
+
+def index(request, sitemaps, **kwargs):
+    sitemaps = prepare_sitemaps(request, sitemaps)
+    return sitemap_views.index(request, sitemaps, **kwargs)
+
+
+def sitemap(request, sitemaps=None, **kwargs):
+    if sitemaps:
+        sitemaps = prepare_sitemaps(request, sitemaps)
+    else:
+        sitemaps = {'wagtail': Sitemap(request.site)}
+    return sitemap_views.sitemap(request, sitemaps, **kwargs)
+
+
+def prepare_sitemaps(request, sitemaps):
+    """Intialize the wagtail Sitemap by passing the request.site value. """
+    initialised_sitemaps = {}
+    for name, sitemap_cls in sitemaps.items():
+        if issubclass(sitemap_cls, Sitemap):
+            initialised_sitemaps[name] = sitemap_cls(request.site)
+        else:
+            initialised_sitemaps[name] = sitemap_cls
+    return initialised_sitemaps


### PR DESCRIPTION
https://projects.torchbox.com/projects/rca-website-rebuild/tickets/133

Due to the older version of wagtail the generator is from a newer version from wagtail.contrib.sitemaps, and the views are a straight copy from the newer version. This is so we can paginate the sitemap and avoid herokus 30 second threshold