### PR TITLE
Use the site.hostname value for the index view rather than the domain…

### DIFF
--- a/django-verdant/rcasitemaps/views.py
+++ b/django-verdant/rcasitemaps/views.py
@@ -7,11 +7,13 @@ from .sitemap_generator import Sitemap
 
 def index(request, sitemaps, **kwargs):
     sitemaps = prepare_sitemaps(request, sitemaps)
-
-    # Workaround: Override the HTTP_HOST and set it as the wagtail.site.hostname value
-    # rather than the host django will set. This is to ensure the sitempat index view
-    # lists all the pages using the hostname set in the wagtail site object, otherwise
-    # the absolute urls on the index listing would begin https://www.mysite.herokuapp.com/...
+    
+    """
+    Workaround: Override the HTTP_HOST and set it as the wagtail.site.hostname value
+    rather than the host django will set. This is to ensure the sitempat index view
+    lists all the pages using the hostname set in the wagtail site object, otherwise
+    the absolute urls on the index listing would begin https://www.mysite.herokuapp.com/...
+    """
     request.META['HTTP_HOST'] = request.site.hostname
     return sitemap_views.index(request, sitemaps, **kwargs)
 

--- a/django-verdant/rcasitemaps/views.py
+++ b/django-verdant/rcasitemaps/views.py
@@ -7,6 +7,12 @@ from .sitemap_generator import Sitemap
 
 def index(request, sitemaps, **kwargs):
     sitemaps = prepare_sitemaps(request, sitemaps)
+
+    # Workaround: Override the HTTP_HOST and set it as the wagtail.site.hostname value
+    # rather than the host django will set. This is to ensure the sitempat index view
+    # lists all the pages using the hostname set in the wagtail site object, otherwise
+    # the absolute urls on the index listing would begin https://www.mysite.herokuapp.com/...
+    request.META['HTTP_HOST'] = request.site.hostname
     return sitemap_views.index(request, sitemaps, **kwargs)
 
 

--- a/django-verdant/rcasitemaps/views.py
+++ b/django-verdant/rcasitemaps/views.py
@@ -10,7 +10,7 @@ def index(request, sitemaps, **kwargs):
     
     """
     Workaround: Override the HTTP_HOST and set it as the wagtail.site.hostname value
-    rather than the host django will set. This is to ensure the sitempat index view
+    rather than the host django will set. This is to ensure the sitemap index view
     lists all the pages using the hostname set in the wagtail site object, otherwise
     the absolute urls on the index listing would begin https://www.mysite.herokuapp.com/...
     """


### PR DESCRIPTION
… from the request so the full path is correct.

~This PR is a straight copy of https://github.com/django/django/blob/1.9.13/django/contrib/sitemaps/views.py#L23~ Override the absolute url value when the index paths are generated here  https://github.com/django/django/blob/1.9.13/django/contrib/sitemaps/views.py#L37 

On stage: https://rca-staging.herokuapp.com/sitemap.xml