### PR TITLE
Circle CI changes to the new deployment config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ jobs:
       - run:
           name: deploy staging to heroku
           command: |
-            git push https://heroku:$HEROKU_TOKEN@git.heroku.com/$HEROKU_APP_NAME_STAGING.git master
+            echo "Deploying to Heroku. To see progress, go to: https://dashboard.heroku.com/apps/$HEROKU_APP_NAME_STAGING/activity"
+            curl -sf -X POST -m 900 https://heroku-deploy.torchbox.com/$HEROKU_APP_NAME_STAGING/$CIRCLE_SHA1?key=$DEPLOYMENT_KEY
   deploy_production:
     docker:
       - image: buildpack-deps:trusty
@@ -61,7 +62,8 @@ jobs:
       - run:
           name: deploy master to heroku
           command: |
-            git push https://heroku:$HEROKU_TOKEN@git.heroku.com/$HEROKU_APP_NAME_PRODUCTION.git master
+            echo "Deploying to Heroku. To see progress, go to: https://dashboard.heroku.com/apps/$HEROKU_APP_NAME_PRODUCTION/activity"
+            curl -sf -X POST -m 900 https://heroku-deploy.torchbox.com/$HEROKU_APP_NAME_PRODUCTION/$CIRCLE_SHA1?key=$DEPLOYMENT_KEY
 
 workflows:
   version: 2


### PR DESCRIPTION
Copied from https://github.com/torchbox/rca-wagtail-2019/pull/396.

UPSTREAM_REPO and DEPLOYMENT_KEY are set on staging and production Heroku apps. 

DEPLOYMENT_KEY should be added as an environment variable to Circle CI.