### PR TITLE
[456] Allow filtering of page results by tag in the API

### DIFF
--- a/django-verdant/rca/api/endpoints.py
+++ b/django-verdant/rca/api/endpoints.py
@@ -32,6 +32,7 @@ class RCAPagesAPIEndpoint(PagesAPIEndpoint):
     known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
         'rp',
         'event_date_from',
+        'tags',
         'tags_not',
     ])
 


### PR DESCRIPTION
This is required to allow the new site to identify related news and events by tag