### PR TITLE
Run apt-get update before ldap is installed in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update
+          command: |
+            sudo apt-get update
+      - run:
           name: Install ldap
           command: |
             sudo apt-get install -y apt-transport-https rsync libldap2-dev libsasl2-dev


### PR DESCRIPTION
So the archive url doesn't 404, E.G

```

Get:4 http://deb.debian.org/debian stretch/main amd64 rsync amd64 3.1.2-1+deb9u2 [393 kB]

Err:5 http://deb.debian.org/debian stretch/main amd64 libldap2-dev amd64 2.4.44+dfsg-5+deb9u3
  404  Not Found

Fetched 923 kB in 0s (4665 kB/s)
E: Failed to fetch http://deb.debian.org/debian/pool/main/o/openldap/libldap2-dev_2.4.44+dfsg-5+deb9u3_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```