### PR TITLE
1089 The twitter /share/ domain is now 'intent', and this was adding bad a…

### DIFF
--- a/django-verdant/rca/templates/rca/includes/modules/share-button.html
+++ b/django-verdant/rca/templates/rca/includes/modules/share-button.html
@@ -6,7 +6,7 @@
 		<h2>Share</h2>
 		<ul>
 			<li><a href="https://www.facebook.com/sharer/sharer.php?u={{ self.url }}">On Facebook</a></li>
-			<li><a href="http://twitter.com/share?text={{ self.title }}&url={{ self.url }}&via={{ global_default_twitter_handle }}">On Twitter</a></li>
+			<li><a href="https://twitter.com/intent/tweet?text={{ self.title }}&url={{ self.url }}&via={{ global_default_twitter_handle }}">On Twitter</a>
 			<li class="last"><a href="mailto:?subject=Royal College of Art: {{ self.title }}&amp;body=I thought you might be interested in this page on the Royal College of Art site: {{ self.url }}.">By Email</a></li>
 		</ul>
 	</div>


### PR DESCRIPTION
…rgs to the share domain

Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1089

This was causing links shared via twitter to unfurl as www.rca.ac.ul/page/subpage/&via=RCA. This will 404. Switching to the `intent` method dodges this and adds the '@via correctly.