### PR TITLE
Fix cache in navigation API

### DIFF
--- a/django-verdant/rca/navigation.py
+++ b/django-verdant/rca/navigation.py
@@ -26,7 +26,6 @@ class Navigation(object):
     def __init__(self, *args):
         self.logger = logging.getLogger("verdant-rca")
         self.cache_key = "navigation_from_api"
-        self.navigation_data = []
 
 
     def fetch_navigation_data(self):
@@ -62,16 +61,17 @@ class Navigation(object):
         Returns:
             A list containing all the navigation data through a cache check
         """
-        if not self.navigation_data and settings.NAVIGATION_API_CONTENT_BASE_URL:
+        navigation_data = cache.get(self.cache_key)
+        if not navigation_data and settings.NAVIGATION_API_CONTENT_BASE_URL:
             try:
-                self.navigation_data = self.fetch_navigation_data()
+                navigation_data = self.fetch_navigation_data()
             except Timeout:
                 return []
             except CantPullFromRcaApi:
                 return []
             else:
-                cache.set(self.cache_key, self.navigation_data, settings.NAVIGATION_API_CACHE_TIMEOUT)
-        return self.navigation_data
+                cache.set(self.cache_key, navigation_data, settings.NAVIGATION_API_CACHE_TIMEOUT)
+        return navigation_data
 
 
     def get_primary_navigation(self):


### PR DESCRIPTION
Fixes the Navigation API wrapper so that cache is correctly used.

Please double check this in a local dev environment before merging as I wasn't able to get a full environment running in the time I had for this.