### PR TITLE
[2426] Remove tabs and render all content

### DIFF
--- a/django-verdant/rca/templates/rca/new_student_page.html
+++ b/django-verdant/rca/templates/rca/new_student_page.html
@@ -11,6 +11,7 @@
     {% tabdeck %}
         {% if self.is_phd_student %}
             {% tab "PhD Work" %}
+                <h2>PhD work</h2>
                 {% get_student_carousel_items self 'phd' as phd_carousel_items %}
                 {% include "rca_show/includes/modules/carousel.html" with carousel_items=phd_carousel_items %}
 
@@ -69,6 +70,7 @@
 
         {% if self.is_mphil_student %}
             {% tab "MPhil work" %}
+                <h2>MPhil work</h2>
                 {% get_student_carousel_items self 'mphil' as mphil_carousel_items %}
                 {% include "rca_show/includes/modules/carousel.html" with carousel_items=mphil_carousel_items %}
 
@@ -127,6 +129,7 @@
 
         {% if self.is_ma_student and self.ma_in_show %}
             {% tab "MA work" %}
+                <h2>MA work</h2>
                 {% get_student_carousel_items self 'ma' as ma_carousel_items %}
                 {% include "rca_show/includes/modules/carousel.html" with carousel_items=ma_carousel_items %}
 
@@ -169,6 +172,7 @@
         {% endif %}
 
         {% tab "Info" %}
+            <h2>Info</h2>
             <div class="profile">
                 <ul class="four-cols">
                     <li class="col first">

--- a/django-verdant/rca/templatetags/rca_tags.py
+++ b/django-verdant/rca/templatetags/rca_tags.py
@@ -642,7 +642,7 @@ class TabDeckNode(template.Node):
         module_title_html = '';
         if self.module_title_expr:
             module_title_html = '<h2 class="module-title">%s</h2>' % self.module_title_expr.resolve(context)
-        return '<section class="row module tabdeck">' + module_title_html + tab_header_html + '<div class="tab-content">' + output + '</div></section>'
+        return '<section class="row module tabdeck">' + module_title_html + '<div class="tab-content">' + output + '</div></section>'
 
 
 @register.tag
@@ -677,18 +677,11 @@ class TabNode(template.Node):
             (' active' if context['tabdeck']['index'] == 1 else ''),
             conditional_escape(heading)
         )
-        if self.extra_classname_expr:
-            classname = "tab-pane %s" % self.extra_classname_expr.resolve(context)
-        else:
-            classname = "tab-pane"
-
-        if context['tabdeck']['index'] == 1:
-            classname += ' active'
 
         context['tabdeck']['tab_headings'].append(heading)
         context['tabdeck']['index'] += 1
 
-        return header_html + ('<div class="%s">' % classname) + self.nodelist.render(context) + '</div>'
+        return header_html + ('<div class="%s">') + self.nodelist.render(context) + '</div>'
 
 # settings value
 @register.assignment_tag


### PR DESCRIPTION
[Codebase ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2426).

As requested, this MR outputs all content previously hidden/shown via the tab bar, and also removes the now redundant tab bar itself.