### PR TITLE
[2445] Improve contrast to meet accessibility requirements

### DIFF
--- a/django-verdant/rca/static/rca/css/modules.less
+++ b/django-verdant/rca/static/rca/css/modules.less
@@ -386,7 +386,7 @@
     }
 
     h3, .tweet-time, .tweet-join {
-        color: @color-dark-grey;
+        color: #6c6c6c;
         display: inline-block;
         margin-top: @spacing-one;
     }
@@ -1333,6 +1333,7 @@ used anywhere. Leaving commented out for now just in case it gets reinstated */
     }
     dt {
         .a2();
+        color: #6c6c6c;
     }
 
     dd {


### PR DESCRIPTION
Ticket [#2445](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2445#update-69556411).

Update colours to meet contrast requirements.

The `.meta-data` class is used on various other templates and therefore they will be overridden too, but my assumption is we'll want this change to be global anyway.