### PR TITLE
[2446] Add new colour to improve link contrast

### DIFF
--- a/django-verdant/rca/static/rca/css/core.less
+++ b/django-verdant/rca/static/rca/css/core.less
@@ -795,7 +795,7 @@ nav {
             padding-right:7%;
 
             &:hover{
-                color:rgb(0, 150, 255) !important;
+                color: @url-blue !important;
             }
         }
 

--- a/django-verdant/rca/static/rca/css/desktop-small.less
+++ b/django-verdant/rca/static/rca/css/desktop-small.less
@@ -27,7 +27,7 @@
  * Template specific styles
  * Search results
  */
- 
+
  .page-wrapper {
  	padding-top: 140px;
  }
@@ -797,7 +797,7 @@ css caused an issue when the css was compressed on the live site */
       width: 47.5%;
       float: left;
       &:last-child {
-        margin-left: 5%; 
+        margin-left: 5%;
       }
     }
     #bboxdonation_billing_billingAddress_lblCAProvincePostCode {

--- a/django-verdant/rca/static/rca/css/modules.less
+++ b/django-verdant/rca/static/rca/css/modules.less
@@ -399,7 +399,7 @@
         .dont-break-out();
         a { /* repeating body-text-style styles here because I don't want to
         screw with the javascript without being able to test it */
-            color: @color-highlight-blue;
+            color: @url-blue;
             .bold();
             &:hover {
                 text-decoration: underline;
@@ -409,7 +409,7 @@
 
     .tweet-join {
         a {
-            color: @color-highlight-blue;
+            color: @url-blue;
             font-family: @font-family-benton;
         }
     }

--- a/django-verdant/rca/static/rca/css/modules.less
+++ b/django-verdant/rca/static/rca/css/modules.less
@@ -1363,7 +1363,7 @@ used anywhere. Leaving commented out for now just in case it gets reinstated */
     }
 
     a {
-        color: @color-highlight-blue;
+        color: @url-blue;
         .bold();
         &:hover {
             text-decoration: underline;
@@ -2206,6 +2206,12 @@ form .hidden-field{
         padding: @spacing-half;
         float: right;
         margin: 0 0 0 @spacing-one;
+    }
+}
+
+.cookie-notice-text {
+    a {
+        color: @color-highlight-blue;
     }
 }
 

--- a/django-verdant/rca/static/rca/css/variables.less
+++ b/django-verdant/rca/static/rca/css/variables.less
@@ -34,7 +34,7 @@
  * $Grid
  */
 
-@grid-columns: 12; 
+@grid-columns: 12;
 @grid-gutter-width: 16px;
 @grid-max-width: 960px;
 @right-col-width: 180px; /* fixed value at all desktop resolutions */
@@ -45,7 +45,7 @@
  */
 
 
-/* $Font family 
+/* $Font family
 * @font-family-[your variant name]
 */
 
@@ -62,7 +62,7 @@ The bold font is a variant of Benton Sans which is not otherwise used on the sit
 you would use 'font-weight:bold;', use the '.bold()' mixin instead */
 
 
-/* $Font sizes 
+/* $Font sizes
 * @font-size-[pxvalue]
 */
 
@@ -93,7 +93,7 @@ you would use 'font-weight:bold;', use the '.bold()' mixin instead */
  */
 
 
- /* Line heights - somewhat arbitrarily named as there are loads of them 
+ /* Line heights - somewhat arbitrarily named as there are loads of them
  (mixin styles which use these are in comments) */
 @line-height-1:  1.2em; /* h1, h2, .module-title (mobile) */
 @line-height-2:  1.194em; /* h3, bc0 */
@@ -180,6 +180,8 @@ you would use 'font-weight:bold;', use the '.bold()' mixin instead */
 
 @color-divider: @color-medium-grey; /* all dark horizontal rules */
 
+/* url colour */
+@url-blue: #077aca;
 
 /**
  * $Other variables.
@@ -192,7 +194,7 @@ you would use 'font-weight:bold;', use the '.bold()' mixin instead */
 @sidebarWidth: 370px;
 
 /**
- * Other variables ported over for site rebuild. 
+ * Other variables ported over for site rebuild.
  * Colours
  */
 
@@ -230,7 +232,7 @@ you would use 'font-weight:bold;', use the '.bold()' mixin instead */
 
 /* FONTS
  * Some typography with font sizes is in the mixin folder.
- * 
+ *
  */
 
 @font--primary: 'Benton Sans', 'BentonSans', 'Helvetica Neue', Arial, Helvetica,


### PR DESCRIPTION
Ticket [#2446](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2446).

Update link colour to meet contrast requirements.

I've reinstated the cookie notice colour, as the new blue fails contrast against the dark grey background.