### PR TITLE
[2447] Prevent main navigation from being focused when it’s closed

### DIFF
--- a/django-verdant/rca/static/rca/css/components/app.less
+++ b/django-verdant/rca/static/rca/css/components/app.less
@@ -32,6 +32,7 @@
         bottom: 0;
         overflow-y: scroll;
         overflow-x: hidden;
+        visibility: hidden;
 
         @media @media-large {
             overflow: hidden;
@@ -39,6 +40,7 @@
 
         .nav-open & {
             pointer-events: all;
+            visibility: visible;
             transform: translate3d(0%, 0%, 0);
             background: @color--black;
 


### PR DESCRIPTION
Ticket [#2447](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2447).

In order to prevent the main navigation from being tab focused, apply the same method as used on the new site.

I've not been able to test this properly locally as I couldn't easily figure out how to add navigation items to the header.