### PR TITLE
Fixups for local docker development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/python:2.7-stretch
+      - image: circleci/python:2.7-buster
         environment:
           SECRET_KEY: testingsecretkey
           SECURE_SSL_REDIRECT: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/python:2.7-buster
+      - image: cimg/python:2.7-node
         environment:
           SECRET_KEY: testingsecretkey
           SECURE_SSL_REDIRECT: false

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ the site will be available on `0.0.0.0:8509`.
 
 Note: this was developed for testing the `Dockerfile` during the Heroku move. It isn't completely working yet for local development.
 
+If working with docker locally, you will need to run the following:
+
+```
+docker exec -it django-verdant_web_1 python manage.py migrate
+docker exec -it django-verdant_web_1 python manage.py createsuperuser
+```
+
 # Deployments
 
 Deployments are handled by [CircleCI](https://circleci.com/gh/torchbox/workflows/verdant-rca).

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Note: this was developed for testing the `Dockerfile` during the Heroku move. It
 If working with docker locally, you will need to run the following:
 
 ```
-docker exec -it django-verdant_web_1 python manage.py migrate
-docker exec -it django-verdant_web_1 python manage.py createsuperuser
+docker exec -it django-verdant-web-1 python manage.py migrate
+docker exec -it django-verdant-web-1 python manage.py createsuperuser
 ```
 
 # Deployments

--- a/django-verdant/Dockerfile
+++ b/django-verdant/Dockerfile
@@ -2,7 +2,7 @@
 # ones becase they use a different C compiler. Debian images also come with
 # all useful packages required for image manipulation out of the box. They
 # however weight a lot, approx. up to 1.5GiB per built image.
-FROM python:2.7-stretch
+FROM python:2.7-buster
 
 RUN useradd verdant-rca
 
@@ -38,10 +38,12 @@ EXPOSE 8000
 # Install operating system dependencies.
 RUN apt-get update -y && \
     apt-get install -y apt-transport-https rsync libldap2-dev libsasl2-dev && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - &&\
-    apt-get install -y nodejs &&\
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+# Check if Node.js and npm are installed
+RUN node -v && npm -v
 
 # Intsall WSGI server - Gunicorn - that will serve the application.
 RUN pip install "gunicorn== 19.9.0"

--- a/django-verdant/dev.Dockerfile
+++ b/django-verdant/dev.Dockerfile
@@ -2,7 +2,7 @@
 # ones becase they use a different C compiler. Debian images also come with
 # all useful packages required for image manipulation out of the box. They
 # however weight a lot, approx. up to 1.5GiB per built image.
-FROM python:2.7-stretch
+FROM python:2.7-buster
 
 RUN useradd verdant-rca
 
@@ -38,10 +38,12 @@ EXPOSE 8000
 # Install operating system dependencies.
 RUN apt-get update -y && \
     apt-get install -y apt-transport-https rsync libldap2-dev libsasl2-dev && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - &&\
-    apt-get install -y nodejs &&\
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+# Check if Node.js and npm are installed
+RUN node -v && npm -v
 
 # Intsall WSGI server - Gunicorn - that will serve the application.
 RUN pip install "gunicorn== 19.9.0"

--- a/django-verdant/requirements.txt
+++ b/django-verdant/requirements.txt
@@ -28,6 +28,7 @@ boto==2.32.0
 certifi==2019.9.11
 scout-apm==2.1.0
 python-magic==0.4.18
+brotli==1.0.7
 
 # Developer requirements
 django-debug-toolbar==0.11.0


### PR DESCRIPTION
This PR updates a few things just to get the site running locally with docker. This codebase is very old and we hadn't planned on doing work on it when we moved it to Heroku, however, we now need to deploy some small FE changes so the site can be crawled by an archive tool.

Whilst doing this, I realised we will have the same issues when we try and deploy the site again so Dockerfile and dev.Dockerfile have been updated.

Staging deploys ok now https://app.circleci.com/pipelines/github/torchbox/verdant-rca/566/workflows/b19c01f3-4fdd-4bd3-a2e9-c0ed753e03c8

