### PR TITLE
[2535/1090] Add logo label and remove menu/search buttons

### DIFF
--- a/django-verdant/rca/static/rca/css/components/header.less
+++ b/django-verdant/rca/static/rca/css/components/header.less
@@ -6,7 +6,7 @@
 
     /**
      * Determines the background colour, this isn't related to the header-content
-     * light or dark classes, or the bg--light and bg--dark. I'm keeping the site 
+     * light or dark classes, or the bg--light and bg--dark. I'm keeping the site
      * intergration with backend as simple as possible for the header.
      */
     background-color: transparent;
@@ -129,7 +129,7 @@
 
     &__menus {
         .grid-layout();
-        
+
         &::before {
             @media @media-large {
                 content: '';
@@ -297,6 +297,36 @@
         }
     }
 
+    &__archive-label {
+        position: absolute;
+        top: 30px;
+        right: 20px;
+        text-align: center;
+
+        @media @media-medium {
+            position: initial;
+            grid-column: 4 / span 2;
+            display: flex;
+            align-items: center;
+            justify-content: end;
+        }
+
+        span {
+            font-family: @font-family-benton-light;
+            background-color: #D9D9D9;
+            color: @color-black;
+            padding: 9px 12px 8px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 12px;
+
+            @media @media-medium {
+                font-size: 18px;
+                padding: 9px 12px 8px;
+            }
+        }
+    }
+
     .theme-light & {
         @{root}__search-toggle,
         @{root}__menu-toggle {
@@ -322,5 +352,5 @@
             color: @color--white;
         }
     }
-    
+
 }

--- a/django-verdant/rca/templates/rca/includes/header.html
+++ b/django-verdant/rca/templates/rca/includes/header.html
@@ -9,11 +9,8 @@
             {% include "rca/includes/modules/logo.html" %}
         </div>
 
-        <div class="header__navigation-toggle bg--light">
-            {% include 'rca/includes/modules/navigation/menu-toggle.html' %}
-            {% include 'rca/includes/modules/navigation/search-toggle.html' %}
+        <div class="header__archive-label">
+            <span>Student Showcase Archive</span>
         </div>
-
     </div>
-
 </div>


### PR DESCRIPTION
Part of the legacy wind down - menu/search buttons removed and new label added. I somehow managed to get the ticket ID wrong on the branch name, sorry about that.

Ticket here: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2535

https://github.com/torchbox/verdant-rca/assets/2553896/bb134976-886e-455d-9158-8dcf2f1a1a9e

